### PR TITLE
Implement simple caching strategy

### DIFF
--- a/src/app/customizer/JsonGenerator/components/CardForm.jsx
+++ b/src/app/customizer/JsonGenerator/components/CardForm.jsx
@@ -41,8 +41,10 @@ export default function CardForm() {
             setResponseData(data.filter(item => Object.keys(item).length !== 0));
             
         }
-        if (previewClicked && !submitClicked) {
+        if (previewClicked && !submitClicked && !categoryData.isDataCached(numRows, responseData, MappedSchema)) {
             jsonPopulate();
+        } else {
+            console.log('Using cached data');
         }
         if (submitClicked && !previewClicked) {
 

--- a/src/app/customizer/JsonGenerator/utils.js
+++ b/src/app/customizer/JsonGenerator/utils.js
@@ -78,4 +78,15 @@ export default class Categories {
             return newMappedSchema;
         }
 
+        isDataCached(currentRowsRequested, previousResponseData, mappedSchema) {
+            return (
+                // Check if a request has already been made for data (check for cached data)
+                previousResponseData.length > 0 &&
+                // Check if the requested data has changed from the previous data requested
+                Object.keys(mappedSchema).sort().join(",") ==
+                Object.keys(previousResponseData[0]).sort().join(",") &&
+                // Check if the number of rows requested is the same as the number of rows in the previous request
+                currentRowsRequested == previousResponseData.length);
+        }
+
 }


### PR DESCRIPTION
Hi,

I defined a method in `utils` to determine whether a new request has to be made when the user sends a request. The current implementation is only used when previewing the data. But we can use the same method when a request is made to save the data as well.